### PR TITLE
Adds dsv to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "documentation-readme": "^2.0.0",
     "tap": "^2.2.0"
+  },
+  "dependencies": {
+    "dsv": "0.0.5"
   }
 }


### PR DESCRIPTION
[dsv](https://www.npmjs.com/package/dsv) is required in [the first line of `index.js`](https://github.com/tmcw/gtfs2geojson/blob/master/index.js#L1), but is not listed as a dependency in the `package.json`.

After running `npm install`, I receive the following error when running `npm test`:

```
test/gtfs2geojson.test.js ............................. 0/1
  not ok Error: Cannot find module 'dsv'
    at:
      file: module.js
      line: 336
      column: 15
      function: Function.Module._resolveFilename
    code: MODULE_NOT_FOUND
    test: TAP
    message: 'Error: Cannot find module ''dsv'''
    stack: |
      Object.<anonymous> (index.js:1:78)
```

This PR adds `dsv` so that the error is no longer thrown during `npm test`. 

I noticed this issue when running `make` when trying to spin up a development instance of geojson.io, where I get the error `module "dsv" not found from "/Users/alexandraulsh/geojson.io/node_modules/gtfs2geojson/index.js"`
